### PR TITLE
Fix: update print statements and checklist items not updating.

### DIFF
--- a/dicompyler/guiutil.py
+++ b/dicompyler/guiutil.py
@@ -176,7 +176,7 @@ class ColorCheckListBox(wx.ScrolledWindow):
         """Removes all items from the control."""
 
         self.items = []
-        self.grid.Clear()
+        self.grid.Clear(True)
         self.grid.Add((0,3), 0)
         self.Layout()
 


### PR DESCRIPTION
Some print statements in dvhcalc.py were updated for Python 3.  Also, when
a new patient was loaded, the old checklist items (structures, isodose levels)
were not being deleted.  The old items would reappear on mouseover.