### PR TITLE
Fix a variety of wx related errors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+patreon: bastula

--- a/dicompyler/baseplugins/2dview.py
+++ b/dicompyler/baseplugins/2dview.py
@@ -674,7 +674,7 @@ class plugin2DView(wx.Panel):
             # Custom cursors with > 2 colors only works on Windows currently
             if guiutil.IsMSWindows():
                 image = wx.Image(util.GetResourcePath('contrast_high.png'))
-                self.SetCursor(wx.CursorFromImage(image))
+                self.SetCursor(wx.Cursor(image))
         # Update the positon and values of the mouse cursor
         self.mousepos = evt.GetPosition()
         self.OnUpdatePositionValues(evt)

--- a/dicompyler/baseplugins/2dview.py
+++ b/dicompyler/baseplugins/2dview.py
@@ -10,7 +10,7 @@
 
 import wx
 from wx.xrc import XmlResource, XRCCTRL, XRCID
-from wx.lib.pubsub import pub
+from pubsub import pub
 from matplotlib import _cntr as cntr
 from matplotlib import __version__ as mplversion
 import numpy as np

--- a/dicompyler/baseplugins/2dview.py
+++ b/dicompyler/baseplugins/2dview.py
@@ -589,13 +589,6 @@ class plugin2DView(wx.Panel):
     def OnKeyDown(self, evt):
         """Change the image when the user presses the appropriate keys."""
 
-        # Needed to work around a bug in Windows. See main.py for more details.
-        if guiutil.IsMSWindows():
-            try:
-                evt = evt.data
-            except AttributeError:
-                keyname = evt.GetKeyCode()
-
         if len(self.images):
             keyname = evt.GetKeyCode()
             prevkey = [wx.WXK_UP, wx.WXK_PAGEUP]
@@ -623,14 +616,6 @@ class plugin2DView(wx.Panel):
 
     def OnMouseWheel(self, evt):
         """Change the image when the user scrolls the mouse wheel."""
-
-        # Needed to work around a bug in Windows. See main.py for more details.
-        if guiutil.IsMSWindows():
-            try:
-                evt = evt.data
-            except AttributeError:
-                delta = evt.GetWheelDelta()
-                rot = evt.GetWheelRotation()
 
         if len(self.images):
             delta = evt.GetWheelDelta()

--- a/dicompyler/baseplugins/anonymize.py
+++ b/dicompyler/baseplugins/anonymize.py
@@ -10,7 +10,7 @@
 
 import wx
 from wx.xrc import XmlResource, XRCCTRL, XRCID
-from wx.lib.pubsub import pub
+from pubsub import pub
 import os, threading
 from dicompyler import guiutil, util
 

--- a/dicompyler/baseplugins/anonymize.xrc
+++ b/dicompyler/baseplugins/anonymize.xrc
@@ -23,12 +23,12 @@
                 </object>
               </object>
             </object>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
           <label>Folder for Anonymized DICOM Files</label>
           <orient>wxVERTICAL</orient>
         </object>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+        <flag>wxALL|wxEXPAND</flag>
         <border>3</border>
       </object>
       <object class="sizeritem">
@@ -63,7 +63,7 @@
               <object class="sizeritem">
                 <object class="wxTextCtrl" name="txtFirstName"/>
                 <option>2</option>
-                <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                <flag>wxALL|wxEXPAND</flag>
               </object>
               <object class="spacer">
                 <size>7,0</size>
@@ -83,12 +83,12 @@
                   <value>anonymous</value>
                 </object>
                 <option>2</option>
-                <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                <flag>wxALL|wxEXPAND</flag>
               </object>
               <orient>wxHORIZONTAL</orient>
             </object>
             <option>1</option>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
           <object class="spacer">
             <size>0,5</size>
@@ -124,7 +124,7 @@
                 <flag>wxALIGN_CENTRE</flag>
               </object>
             </object>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
           <object class="spacer">
             <size>0,5</size>
@@ -169,7 +169,7 @@
           <label>Options</label>
           <orient>wxVERTICAL</orient>
         </object>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+        <flag>wxALL|wxEXPAND</flag>
         <border>3</border>
       </object>
       <object class="spacer">
@@ -191,7 +191,7 @@
             </object>
           </object>
         </object>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+        <flag>wxALL|wxEXPAND</flag>
         <border>3</border>
       </object>
       <object class="spacer">

--- a/dicompyler/baseplugins/dvh.py
+++ b/dicompyler/baseplugins/dvh.py
@@ -12,7 +12,7 @@
 
 import wx
 from wx.xrc import XmlResource, XRCCTRL, XRCID
-from wx.lib.pubsub import pub
+from pubsub import pub
 from dicompyler import guiutil, util
 from dicompyler import guidvh
 import numpy as np

--- a/dicompyler/baseplugins/dvh.xrc
+++ b/dicompyler/baseplugins/dvh.xrc
@@ -10,12 +10,12 @@
           <object class="sizeritem">
             <object class="unknown" name="panelDVH"/>
             <option>1</option>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE|wxADJUST_MINSIZE</flag>
+            <flag>wxALL|wxEXPAND|wxADJUST_MINSIZE</flag>
             <border>4</border>
           </object>
         </object>
         <option>5</option>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+        <flag>wxALL|wxEXPAND</flag>
       </object>
       <object class="sizeritem">
         <object class="wxBoxSizer">
@@ -74,7 +74,7 @@
                   <min>0</min>
                 </object>
                 <option>4</option>
-                <flag>wxALL|wxEXPAND|wxALIGN_CENTRE_VERTICAL</flag>
+                <flag>wxALL|wxEXPAND</flag>
               </object>
               <object class="spacer">
                 <size>3,0</size>
@@ -126,12 +126,12 @@
               </object>
             </object>
             <option>2</option>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
           <orient>wxHORIZONTAL</orient>
         </object>
         <option>0</option>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+        <flag>wxALL|wxEXPAND</flag>
       </object>
       <orient>wxVERTICAL</orient>
     </object>

--- a/dicompyler/baseplugins/dvh.xrc
+++ b/dicompyler/baseplugins/dvh.xrc
@@ -27,7 +27,7 @@
                 <object class="wxStaticText" name="lblType">
                   <label>Type:</label>
                 </object>
-                <flag>wxALIGN_RIGHT|wxALIGN_CENTRE_VERTICAL</flag>
+                <flag>wxALIGN_CENTRE_VERTICAL</flag>
               </object>
               <object class="spacer">
                 <size>3,0</size>
@@ -42,7 +42,7 @@
                   </content>
                   <selection>0</selection>
                 </object>
-                <flag>wxALIGN_LEFT|wxALIGN_CENTRE_VERTICAL</flag>
+                <flag>wxALIGN_CENTRE_VERTICAL</flag>
               </object>
               <object class="spacer">
                 <size>5,0</size>
@@ -52,7 +52,7 @@
                 <object class="wxStaticText" name="lblConstraintType">
                   <label>   Dose:</label>
                 </object>
-                <flag>wxALIGN_RIGHT|wxALIGN_CENTRE_VERTICAL</flag>
+                <flag>wxALIGN_CENTRE_VERTICAL</flag>
               </object>
               <object class="spacer">
                 <size>3,0</size>
@@ -83,7 +83,7 @@
                 <object class="wxStaticText" name="lblConstraintTypeUnits">
                   <label>%  </label>
                 </object>
-                <flag>wxALIGN_LEFT|wxALIGN_CENTRE_VERTICAL</flag>
+                <flag>wxALIGN_CENTRE_VERTICAL</flag>
               </object>
               <object class="spacer">
                 <size>5,0</size>

--- a/dicompyler/baseplugins/quickopen.py
+++ b/dicompyler/baseplugins/quickopen.py
@@ -11,7 +11,7 @@
 import logging
 logger = logging.getLogger('dicompyler.quickimport')
 import wx
-from wx.lib.pubsub import pub
+from pubsub import pub
 from dicompylercore import dicomparser
 from dicompyler import util
 

--- a/dicompyler/baseplugins/treeview.py
+++ b/dicompyler/baseplugins/treeview.py
@@ -14,7 +14,7 @@ import threading
 from six.moves import queue
 import wx
 from wx.xrc import XmlResource, XRCCTRL, XRCID
-from wx.lib.pubsub import pub
+from pubsub import pub
 from wx.dataview import TreeListCtrl as tlc
 from dicompyler import guiutil, util
 try:

--- a/dicompyler/baseplugins/treeview.xrc
+++ b/dicompyler/baseplugins/treeview.xrc
@@ -25,7 +25,7 @@
           <orient>wxVERTICAL</orient>
         </object>
         <option>0</option>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+        <flag>wxALL|wxEXPAND</flag>
         <border>1</border>
       </object>
       <object class="spacer">
@@ -39,16 +39,16 @@
               <object class="sizeritem">
                 <object class="unknown" name="tlcTreeView"/>
                 <option>1</option>
-                <flag>wxALL|wxEXPAND|wxALIGN_CENTRE|wxADJUST_MINSIZE</flag>
+                <flag>wxALL|wxEXPAND|wxADJUST_MINSIZE</flag>
               </object>
             </object>
             <option>3</option>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
           <orient>wxVERTICAL</orient>
         </object>
         <option>5</option>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+        <flag>wxALL|wxEXPAND</flag>
       </object>
       <orient>wxVERTICAL</orient>
     </object>

--- a/dicompyler/dicomgui.py
+++ b/dicompyler/dicomgui.py
@@ -15,7 +15,7 @@ logger = logging.getLogger('dicompyler.dicomgui')
 import hashlib, os, threading
 import wx
 from wx.xrc import *
-from wx.lib.pubsub import pub
+from pubsub import pub
 import numpy as np
 from dicompylercore import dicomparser
 from dicompyler import guiutil, util

--- a/dicompyler/guiutil.py
+++ b/dicompyler/guiutil.py
@@ -10,7 +10,7 @@
 from dicompyler import util
 import wx
 from wx.xrc import XmlResource, XRCCTRL, XRCID
-from wx.lib.pubsub import pub
+from pubsub import pub
 
 def IsMSWindows():
     """Are we running on Windows?

--- a/dicompyler/guiutil.py
+++ b/dicompyler/guiutil.py
@@ -200,7 +200,7 @@ class ColorCheckBox(wx.Panel):
         grid.Add((3,0), 0)
         grid.Add(self.colorbox, 0, flag=wx.ALIGN_CENTRE)
         grid.Add((5,0), 0)
-        grid.Add(self.checkbox, 1, flag=wx.EXPAND|wx.ALL|wx.ALIGN_CENTRE)
+        grid.Add(self.checkbox, 1, flag=wx.EXPAND|wx.ALL)
 
         # Decrease the font size on Mac
         if IsMac():

--- a/dicompyler/main.py
+++ b/dicompyler/main.py
@@ -20,7 +20,7 @@ from wx.xrc import *
 import wx.adv
 import wx.lib.dialogs, webbrowser
 import pydicom
-from wx.lib.pubsub import pub
+from pubsub import pub
 from dicompylercore import dvhcalc
 from dicompyler import __version__
 from dicompyler import guiutil, util

--- a/dicompyler/main.py
+++ b/dicompyler/main.py
@@ -833,7 +833,7 @@ class MainFrame(wx.Frame):
             notebook tab instead of the panel receives focus."""
 
         if guiutil.IsMSWindows():
-            pub.sendMessage('main.key_down', msg=evt)
+            pub.sendMessage('main.key_down', evt=evt)
 
     def OnMouseWheel(self, evt):
         """Capture the mousewheel event when the notebook tab is focused.
@@ -841,7 +841,7 @@ class MainFrame(wx.Frame):
             notebook tab instead of the panel receives focus."""
 
         if guiutil.IsMSWindows():
-            pub.sendMessage('main.mousewheel', msg=evt)
+            pub.sendMessage('main.mousewheel', evt=evt)
 
     def OnPreferences(self, evt):
         """Load and show the Preferences dialog box."""

--- a/dicompyler/main.py
+++ b/dicompyler/main.py
@@ -129,11 +129,11 @@ class MainFrame(wx.Frame):
         mainGrid = wx.BoxSizer(wx.VERTICAL)
         hGrid = wx.BoxSizer(wx.HORIZONTAL)
         if guiutil.IsMac():
-            hGrid.Add(self.panelGeneral, 1, flag=wx.EXPAND|wx.ALL|wx.ALIGN_CENTRE, border=4)
+            hGrid.Add(self.panelGeneral, 1, flag=wx.EXPAND|wx.ALL, border=4)
         else:
-            hGrid.Add(self.panelGeneral, 1, flag=wx.EXPAND|wx.ALL|wx.ALIGN_CENTRE)
+            hGrid.Add(self.panelGeneral, 1, flag=wx.EXPAND|wx.ALL)
 
-        mainGrid.Add(hGrid, 1, flag=wx.EXPAND|wx.ALL|wx.ALIGN_CENTRE)
+        mainGrid.Add(hGrid, 1, flag=wx.EXPAND|wx.ALL)
 
         # Load the menu for the frame
         menuMain = self.res.LoadMenuBar('menuMain')

--- a/dicompyler/plugin.py
+++ b/dicompyler/plugin.py
@@ -12,7 +12,7 @@ logger = logging.getLogger('dicompyler.plugin')
 import imp, os
 import wx
 from wx.xrc import *
-from wx.lib.pubsub import pub
+from pubsub import pub
 from dicompyler import guiutil, util
 
 def import_plugins(userpath=None):

--- a/dicompyler/preferences.py
+++ b/dicompyler/preferences.py
@@ -377,7 +377,7 @@ def main():
 
     import tempfile, os
     import wx
-    from pubsub import Publisher as pub
+    from pubsub import pub
 
     app = wx.App(False)
 

--- a/dicompyler/preferences.py
+++ b/dicompyler/preferences.py
@@ -10,7 +10,7 @@
 import os
 import wx
 from wx.xrc import *
-from wx.lib.pubsub import pub
+from pubsub import pub
 from dicompyler import guiutil, util
 
 try:
@@ -377,7 +377,7 @@ def main():
 
     import tempfile, os
     import wx
-    from wx.lib.pubsub import Publisher as pub
+    from pubsub import Publisher as pub
 
     app = wx.App(False)
 

--- a/dicompyler/resources/dicomgui.xrc
+++ b/dicompyler/resources/dicomgui.xrc
@@ -12,7 +12,7 @@
                   <style>wxTE_READONLY</style>
                 </object>
                 <option>1</option>
-                <flag>wxALIGN_LEFT|wxALIGN_CENTRE_VERTICAL</flag>
+                <flag>wxALIGN_CENTRE_VERTICAL</flag>
               </object>
               <object class="spacer">
                 <size>5,0</size>

--- a/dicompyler/resources/dicomgui.xrc
+++ b/dicompyler/resources/dicomgui.xrc
@@ -23,7 +23,7 @@
                 </object>
               </object>
             </object>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
           <label>DICOM Import Location</label>
           <orient>wxVERTICAL</orient>
@@ -41,7 +41,7 @@
             </object>
           </object>
         </object>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+        <flag>wxALL|wxEXPAND</flag>
         <border>3</border>
       </object>
       <object class="sizeritem">
@@ -50,18 +50,18 @@
             <object class="wxBoxSizer">
               <object class="spacer">
                 <size>2,0</size>
-                <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                <flag>wxALL|wxEXPAND</flag>
               </object>
               <object class="sizeritem">
                 <object class="wxStaticBitmap" name="bmpDirections">
                   <bitmap>accept.png</bitmap>
                 </object>
-                <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                <flag>wxALL|wxEXPAND</flag>
                 <minsize>16,16</minsize>
               </object>
               <object class="spacer">
                 <size>2,0</size>
-                <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                <flag>wxALL|wxEXPAND</flag>
               </object>
               <object class="sizeritem">
                 <object class="wxBoxSizer">
@@ -82,11 +82,11 @@
                   <orient>wxVERTICAL</orient>
                 </object>
                 <option>1</option>
-                <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                <flag>wxALL|wxEXPAND</flag>
               </object>
               <orient>wxHORIZONTAL</orient>
             </object>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
           <object class="spacer">
             <size>0,5</size>
@@ -97,7 +97,7 @@
               <style>wxSUNKEN_BORDER|wxTR_HAS_BUTTONS|wxTR_LINES_AT_ROOT|wxTR_SINGLE</style>
             </object>
             <option>1</option>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
           <object class="spacer">
             <size>0,5</size>
@@ -148,7 +148,7 @@
               </object>
               <orient>wxHORIZONTAL</orient>
             </object>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
           <object class="spacer">
             <size>0,5</size>
@@ -200,14 +200,14 @@
               </object>
               <orient>wxHORIZONTAL</orient>
             </object>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
           <object class="spacer">
             <size>0,9</size>
           </object>
           <orient>wxVERTICAL</orient>
         </object>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+        <flag>wxALL|wxEXPAND</flag>
         <border>3</border>
       </object>
       <object class="spacer">
@@ -229,7 +229,7 @@
             </object>
           </object>
         </object>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+        <flag>wxALL|wxEXPAND</flag>
         <border>3</border>
       </object>
       <object class="spacer">

--- a/dicompyler/resources/guiutil.xrc
+++ b/dicompyler/resources/guiutil.xrc
@@ -22,7 +22,7 @@
               </object>
               <orient>wxHORIZONTAL</orient>
             </object>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
           <object class="spacer">
             <size>5,0</size>
@@ -34,7 +34,7 @@
               <value>0</value>
               <style>wxGA_HORIZONTAL|wxGA_SMOOTH</style>
             </object>
-            <flag>wxLEFT|wxRIGHT|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
           </object>
           <object class="sizeritem">
             <object class="wxBoxSizer">
@@ -64,7 +64,7 @@
           <growablerows>1</growablerows>
         </object>
         <option>1</option>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+        <flag>wxALL|wxEXPAND</flag>
         <border>10</border>
       </object>
     </object>

--- a/dicompyler/resources/main.xrc
+++ b/dicompyler/resources/main.xrc
@@ -22,7 +22,7 @@
                       <label>-</label>
                     </object>
                     <option>1</option>
-                    <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                    <flag>wxALL|wxEXPAND</flag>
                   </object>
                   <object class="sizeritem">
                     <object class="wxStaticText"/>
@@ -38,7 +38,7 @@
                       <label>-</label>
                     </object>
                     <option>1</option>
-                    <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                    <flag>wxALL|wxEXPAND</flag>
                   </object>
                   <object class="sizeritem">
                     <object class="wxStaticText">
@@ -53,10 +53,10 @@
                   <growablecols>1</growablecols>
                 </object>
                 <option>1</option>
-                <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                <flag>wxALL|wxEXPAND</flag>
               </object>
             </object>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
           <object class="sizeritem">
             <object class="wxBoxSizer">
@@ -64,11 +64,11 @@
               <object class="sizeritem">
                 <object class="wxNotebook" name="notebookTools"/>
                 <option>1</option>
-                <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                <flag>wxALL|wxEXPAND</flag>
               </object>
             </object>
             <option>3</option>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
           <object class="sizeritem">
             <object class="wxStaticBoxSizer">
@@ -80,7 +80,7 @@
                   <selection>1</selection>
                   <enabled>0</enabled>
                 </object>
-                <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                <flag>wxALL|wxEXPAND</flag>
                 <ratio>0</ratio>
               </object>
               <object class="spacer">
@@ -159,17 +159,17 @@
                   <growablecols>1</growablecols>
                 </object>
                 <option>1</option>
-                <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                <flag>wxALL|wxEXPAND</flag>
               </object>
               <label>Structure Information</label>
               <orient>wxVERTICAL</orient>
             </object>
-            <flag>wxLEFT|wxRIGHT|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
           </object>
           <orient>wxVERTICAL</orient>
         </object>
         <option>3</option>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+        <flag>wxALL|wxEXPAND</flag>
         <border>1</border>
       </object>
       <object class="sizeritem">
@@ -188,7 +188,7 @@
                     <object class="wxStaticText" name="lblPatientName">
                     </object>
                     <option>1</option>
-                    <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                    <flag>wxALL|wxEXPAND</flag>
                   </object>
                   <object class="sizeritem">
                     <object class="wxStaticText">
@@ -199,7 +199,7 @@
                   <object class="sizeritem">
                     <object class="wxStaticText" name="lblPatientID"/>
                     <option>1</option>
-                    <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                    <flag>wxALL|wxEXPAND</flag>
                   </object>
                   <object class="sizeritem">
                     <object class="wxStaticText">
@@ -209,7 +209,7 @@
                   <object class="sizeritem">
                     <object class="wxStaticText" name="lblPatientGender"/>
                     <option>1</option>
-                    <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                    <flag>wxALL|wxEXPAND</flag>
                   </object>
                   <object class="sizeritem">
                     <object class="wxStaticText">
@@ -219,7 +219,7 @@
                   <object class="sizeritem">
                     <object class="wxStaticText" name="lblPatientDOB"/>
                     <option>1</option>
-                    <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                    <flag>wxALL|wxEXPAND</flag>
                   </object>
                   <cols>8</cols>
                   <rows>2</rows>
@@ -234,28 +234,28 @@
               <orient>wxVERTICAL</orient>
             </object>
             <option>0</option>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
           <object class="sizeritem">
             <object class="wxBoxSizer">
               <object class="spacer">
                 <size>0,2</size>
-                <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                <flag>wxALL|wxEXPAND</flag>
               </object>
               <object class="sizeritem">
                 <object class="wxNotebook" name="notebook"/>
                 <option>1</option>
-                <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                <flag>wxALL|wxEXPAND</flag>
               </object>
               <orient>wxVERTICAL</orient>
             </object>
             <option>1</option>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
           <orient>wxVERTICAL</orient>
         </object>
         <option>11</option>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+        <flag>wxALL|wxEXPAND</flag>
         <border>3</border>
       </object>
     </object>
@@ -267,13 +267,13 @@
         <object class="wxBoxSizer">
           <object class="spacer">
             <option>1</option>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
           <object class="sizeritem">
             <object class="wxBoxSizer">
               <object class="spacer">
                 <option>1</option>
-                <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                <flag>wxALL|wxEXPAND</flag>
               </object>
               <object class="sizeritem">
                 <object class="wxBoxSizer">
@@ -288,35 +288,35 @@
                     <object class="wxBoxSizer">
                       <object class="spacer">
                         <option>1</option>
-                        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                        <flag>wxALL|wxEXPAND</flag>
                       </object>
                       <object class="sizeritem">
                         <object class="wxStaticText" name="lblVersion">
                           <label>Version xxxx</label>
                           <style>wxALIGN_RIGHT</style>
                         </object>
-                        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                        <flag>wxALL|wxEXPAND</flag>
                       </object>
                       <orient>wxHORIZONTAL</orient>
                     </object>
-                    <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                    <flag>wxALL|wxEXPAND</flag>
                   </object>
                 </object>
               </object>
               <object class="spacer">
                 <option>1</option>
-                <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                <flag>wxALL|wxEXPAND</flag>
               </object>
               <orient>wxHORIZONTAL</orient>
             </object>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
           <orient>wxVERTICAL</orient>
           <object class="sizeritem">
             <object class="wxBoxSizer">
               <object class="spacer">
                 <option>1</option>
-                <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                <flag>wxALL|wxEXPAND</flag>
               </object>
               <object class="sizeritem">
                 <object class="wxBoxSizer">
@@ -324,22 +324,22 @@
                     <object class="wxBoxSizer">
                       <object class="spacer">
                         <option>1</option>
-                        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                        <flag>wxALL|wxEXPAND</flag>
                       </object>
                       <object class="sizeritem">
                         <object class="wxStaticText" name="lblGetStarted">
                           <label>\n\nWelcome to dicompyler. To get started, open a patient file.</label>
                           <style>wxALIGN_CENTRE</style>
                         </object>
-                        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                        <flag>wxALL|wxEXPAND</flag>
                       </object>
                       <object class="spacer">
                         <option>1</option>
-                        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                        <flag>wxALL|wxEXPAND</flag>
                       </object>
                       <orient>wxHORIZONTAL</orient>
                     </object>
-                    <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                    <flag>wxALL|wxEXPAND</flag>
                   </object>
                   <object class="sizeritem">
                     <object class="wxBoxSizer">
@@ -357,11 +357,11 @@
                         <object class="wxStaticText" name="lblDisclaimerHeader">
                           <label>\n\n\nDisclaimer:</label>
                         </object>
-                        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                        <flag>wxALL|wxEXPAND</flag>
                       </object>
                       <orient>wxHORIZONTAL</orient>
                     </object>
-                    <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                    <flag>wxALL|wxEXPAND</flag>
                   </object>
                   <object class="sizeritem">
                     <object class="wxStaticText" name="lblDisclaimer">
@@ -370,23 +370,23 @@
                   </object>
                   <orient>wxVERTICAL</orient>
                 </object>
-                <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                <flag>wxALL|wxEXPAND</flag>
               </object>
               <object class="spacer">
                 <option>1</option>
-                <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                <flag>wxALL|wxEXPAND</flag>
               </object>
               <orient>wxHORIZONTAL</orient>
             </object>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
           <object class="spacer">
             <option>1</option>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
         </object>
         <option>1</option>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+        <flag>wxALL|wxEXPAND</flag>
       </object>
       <object class="sizeritem">
         <object class="wxBoxSizer">

--- a/dicompyler/resources/plugin.xrc
+++ b/dicompyler/resources/plugin.xrc
@@ -25,11 +25,11 @@
                         <style>wxNO_BORDER|wxTR_NO_BUTTONS|wxTR_NO_LINES|wxTR_FULL_ROW_HIGHLIGHT|wxTR_HIDE_ROOT</style>
                       </object>
                       <option>1</option>
-                      <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                      <flag>wxALL|wxEXPAND</flag>
                     </object>
                   </object>
                 </object>
-                <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                <flag>wxALL|wxEXPAND</flag>
               </object>
               <object class="spacer">
                 <size>10,0</size>
@@ -67,7 +67,7 @@
                         <object class="spacer">
                           <size>5,0</size>
                           <option>1</option>
-                          <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                          <flag>wxALL|wxEXPAND</flag>
                         </object>
                         <object class="sizeritem">
                           <object class="wxStaticText" name="lblVersion">
@@ -84,7 +84,7 @@
                         </object>
                         <orient>wxHORIZONTAL</orient>
                       </object>
-                      <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                      <flag>wxALL|wxEXPAND</flag>
                     </object>
                     <object class="spacer">
                       <size>0,7</size>
@@ -110,7 +110,7 @@
                         <object class="spacer">
                           <size>5,0</size>
                           <option>1</option>
-                          <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                          <flag>wxALL|wxEXPAND</flag>
                         </object>
                         <object class="sizeritem">
                           <object class="wxCheckBox" name="checkEnabled">
@@ -119,7 +119,7 @@
                         </object>
                         <orient>wxHORIZONTAL</orient>
                       </object>
-                      <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                      <flag>wxALL|wxEXPAND</flag>
                     </object>
                     <object class="spacer">
                       <size>0,5</size>
@@ -137,29 +137,29 @@
                                 <label>Description</label>
                               </object>
                               <option>1</option>
-                              <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                              <flag>wxALL|wxEXPAND</flag>
                             </object>
                             <orient>wxHORIZONTAL</orient>
                           </object>
                           <option>1</option>
-                          <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                          <flag>wxALL|wxEXPAND</flag>
                         </object>
                         <orient>wxVERTICAL</orient>
                       </object>
                       <option>1</option>
-                      <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                      <flag>wxALL|wxEXPAND</flag>
                     </object>
                   </object>
                 </object>
                 <option>1</option>
-                <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+                <flag>wxALL|wxEXPAND</flag>
               </object>
               <object class="spacer">
                 <size>5,5</size>
               </object>
             </object>
             <option>1</option>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
           <object class="spacer">
             <size>0,5</size>
@@ -167,7 +167,7 @@
           <orient>wxVERTICAL</orient>
         </object>
         <option>1</option>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+        <flag>wxALL|wxEXPAND</flag>
         <border>3</border>
       </object>
       <object class="sizeritem">
@@ -175,7 +175,7 @@
           <object class="spacer">
             <size>0,5</size>
             <option>1</option>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
           <object class="sizeritem">
             <object class="wxStaticText" name="lblMessage">
@@ -187,28 +187,28 @@
           <object class="spacer">
             <size>0,5</size>
             <option>1</option>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
           </object>
           <object class="sizeritem">
             <object class="wxButton" name="wxID_OK">
               <label>&amp;Close</label>
             </object>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
             <border>3</border>
           </object>
           <object class="spacer">
             <size>0,5</size>
-            <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+            <flag>wxALL|wxEXPAND</flag>
             <border>3</border>
           </object>
           <orient>wxHORIZONTAL</orient>
         </object>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+        <flag>wxALL|wxEXPAND</flag>
       </object>
       <orient>wxVERTICAL</orient>
       <object class="spacer">
         <size>10,10</size>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+        <flag>wxALL|wxEXPAND</flag>
       </object>
     </object>
     <size>600,400</size>

--- a/dicompyler/resources/preferences.xrc
+++ b/dicompyler/resources/preferences.xrc
@@ -7,7 +7,7 @@
           <size>550,350</size>
         </object>
         <option>1</option>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+        <flag>wxALL|wxEXPAND</flag>
         <border>7</border>
       </object>
       <orient>wxVERTICAL</orient>
@@ -19,7 +19,7 @@
             </object>
           </object>
         </object>
-        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE</flag>
+        <flag>wxALL|wxEXPAND</flag>
         <border>7</border>
       </object>
     </object>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dicompyler-core[image]>=0.5.2
 wxPython>=4.0.0b2
-matplotlib>=1.3
+matplotlib>=1.3,<2.2
 numpy>=1.13.1
 https://github.com/darcymason/pydicom/archive/master.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ wxPython>=4.0.0b2
 matplotlib>=1.3,<2.2
 numpy>=1.13.1
 https://github.com/darcymason/pydicom/archive/master.zip
+
+# Fix #131
+PyPubSub

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@
 from setuptools import setup, find_packages
 
 requires = [
-    'matplotlib>=1.3.0',
+    'matplotlib>=1.3.0,<2.2',
     'numpy>=1.2.1',
     'pillow>=1.0',
     'dicompyler-core>=0.5.2',


### PR DESCRIPTION
While running dicompyler from source with the requirements from requirements.txt installed I get a lot of errors, this PR should address them to make dicompyler stop throwing wx related errors.

Among others it fixes:
- wx.lib.pubsub being deprecated in favor of PyPubSub
- fix layout errors for options not valid in horizontal box sizer
- use wx.Cursor in favor of deprecated wx.CursorFromImage()
- remove wxALIGN* where WX_EXPAND is also set

This also incorporates the fixes of #131.